### PR TITLE
[logentry] add service & user field to log entries

### DIFF
--- a/log_entry.go
+++ b/log_entry.go
@@ -11,7 +11,8 @@ type Agent APIObject
 
 // Channel is the means by which the action was carried out.
 type Channel struct {
-	Type string
+	Type         string
+	Notification Notification
 }
 
 // Context are to be included with the trigger such as links to graphs or images.
@@ -34,6 +35,8 @@ type LogEntry struct {
 	Contexts               []Context
 	AcknowledgementTimeout int `json:"acknowledgement_timeout"`
 	EventDetails           map[string]string
+	Service                Service
+	User                   User
 }
 
 // ListLogEntryResponse is the response data when calling the ListLogEntry API endpoint.


### PR DESCRIPTION
I mainly want to add the user field so I can use it to parse the notified user in a log entry.
bonus is that I can get the notification and service as well.

Mostly copied from this [PR](https://github.com/PagerDuty/go-pagerduty/pull/201) that they refuse to merge